### PR TITLE
break out of the attempts-loop after a successful request

### DIFF
--- a/mantrid/actions.py
+++ b/mantrid/actions.py
@@ -154,6 +154,7 @@ class Proxy(Action):
             try:
                 size = send_onwards(read_data)
                 size += SocketMelder(sock, server_sock).run()
+                break
             except socket.error, e:
                 if e.errno != errno.EPIPE:
                     raise


### PR DESCRIPTION
a simple one-line fix to break the attempts loop when a successful proxy-ing occured
